### PR TITLE
don't barf on empty lines

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,7 @@ module.exports = function (handler, docker) {
                 // positive: create, restart, start
                 // negative: destroy, die, kill, stop
                 data.on('data', function (chunk) {
-                    var lines = chunk.toString().split('\n');
+                    var lines = chunk.toString().replace(/\n$/, "").split('\n');                    
                     lines.forEach(function (line) {
                         try {
                             processDockerEvent(JSON.parse(line));


### PR DESCRIPTION
some events from dockerode seem to have an additional blank newline, which then caused the json parse to fail, which then raised an error in the console. This commit trims newlines from the chunk before looping through the lines
